### PR TITLE
Popover arrow positioning + BoxedListWithLinks click area

### DIFF
--- a/packages/@navikt/boxed-list-with-links/package.json
+++ b/packages/@navikt/boxed-list-with-links/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/boxed-list-with-links",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "",
     "main": "dist/BoxedListWithLinks.js",
     "module": "dist/BoxedListWithLinks.js",

--- a/packages/@navikt/boxed-list-with-links/src/list.less
+++ b/packages/@navikt/boxed-list-with-links/src/list.less
@@ -12,4 +12,5 @@
 .boxedList__item__anchor {
     text-decoration: none;
     color: rgb(0, 115, 209);
+    width: 100%;
 }

--- a/packages/@navikt/popover/package.json
+++ b/packages/@navikt/popover/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/nap-popover",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "author": "NAV",
     "license": "MIT",
     "main": "dist/popover.js",

--- a/packages/@navikt/popover/src/popover.tsx
+++ b/packages/@navikt/popover/src/popover.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Manager, Popper, PopperProps, Reference, ReferenceProps } from 'react-popper';
+import { Manager, Popper, PopperProps, Reference, ReferenceProps, PopperArrowProps as ArrowProps } from 'react-popper';
 
 interface PopoverProps {
     popperProps: PopperProps;
+    arrowProps?: Partial<ArrowProps>;
     referenceProps: ReferenceProps;
     popperIsVisible: boolean;
     renderArrowElement?: boolean;
@@ -15,6 +16,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
     popperIsVisible,
     renderArrowElement,
     customPopperStyles,
+    arrowProps,
 }) => {
     const { children, ...otherPopperProps } = popperProps;
     const [shouldRepaint, setShouldRepaint] = React.useState(false);
@@ -33,7 +35,8 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
             <Reference {...referenceProps} />
             <Popper {...otherPopperProps}>
                 {(popperChildrenProps): React.ReactNode => {
-                    const { placement, ref, style, arrowProps, scheduleUpdate } = popperChildrenProps;
+                    const { placement, ref, style, scheduleUpdate } = popperChildrenProps;
+                    const allArrowProps = { ...popperChildrenProps.arrowProps, ...arrowProps };
                     repaint(scheduleUpdate);
                     return (
                         <div
@@ -45,7 +48,9 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
                                 visibility: popperIsVisible ? 'visible' : 'hidden',
                             }}
                         >
-                            {renderArrowElement && <div {...arrowProps} className="arrow" data-placement={placement} />}
+                            {renderArrowElement && (
+                                <div {...allArrowProps} className="arrow" data-placement={placement} />
+                            )}
                             {children(popperChildrenProps)}
                         </div>
                     );

--- a/packages/stories/Header.stories.tsx
+++ b/packages/stories/Header.stories.tsx
@@ -3,6 +3,7 @@ import Header from '../@navikt/header/src/index';
 import Popover from '../@navikt/popover/src/popover';
 import SystemButton from '../@navikt/system-button/src';
 import BoxedListWithSelection from '../@navikt/boxed-list-with-selection/src/BoxedListWithSelection';
+import BoxedListWithLinks from '../@navikt/boxed-list-with-links/src/BoxedListWithLinks';
 import UserPanel from '../@navikt/user-panel/src';
 
 export default { title: '@navikt/nap-header' };
@@ -16,13 +17,13 @@ export const standard: React.FunctionComponent = () => {
             <Popover
                 popperIsVisible={linkWindowOpen}
                 renderArrowElement
-                customPopperStyles={{ top: '8px', zIndex: 1 }}
+                customPopperStyles={{ top: '12px', zIndex: 1 }}
                 popperProps={{
                     children: () => (
-                        <BoxedListWithSelection
+                        <BoxedListWithLinks
                             items={[
-                                { name: 'Test 1', href: 'nav.no' },
-                                { name: 'Test 2', href: 'localhost:1234' },
+                                { name: 'Test 1', href: 'https://www.nav.no', isExternal: true },
+                                { name: 'Test 2', href: 'https://github.com/navikt/not-a-platform' },
                             ]}
                             onClick={() => {
                                 setLinkWindowOpen(false);
@@ -50,19 +51,12 @@ export const standard: React.FunctionComponent = () => {
             />
             <Popover
                 popperIsVisible={unitWindowOpen}
-                customPopperStyles={{ top: '8px', zIndex: 1 }}
+                customPopperStyles={{ top: '12px', zIndex: 1 }}
                 renderArrowElement
                 popperProps={{
                     children: () => (
                         <BoxedListWithSelection
-                            items={[
-                                {
-                                    name: 'Test 1',
-                                    href: 'nav.no',
-                                    selected: true,
-                                },
-                                { name: 'Test 2', href: 'localhost:1234' },
-                            ]}
+                            items={[{ name: 'Test 1', selected: true }, { name: 'Test 2' }]}
                             onClick={() => {
                                 setUnitWindowOpen(false);
                             }}
@@ -87,6 +81,7 @@ export const standard: React.FunctionComponent = () => {
                         </div>
                     ),
                 }}
+                arrowProps={{ style: { left: '140px' } }}
             />
         </Header>
     );


### PR DESCRIPTION
Makes it possible to adjust positioning of arrow in popover component by
specifying styles in a new arrowProps-prop on the <Popover>-component.

Fix issue where BoxedListWithLinks-anchors didnt take up 100% width which
resulted in list elements not being clickable outside the borders of the anchor

Update versions of popover and boxed-list-with-links