### PR TITLE
Fix spacing in <ProcessMenu>

### DIFF
--- a/packages/@navikt/process-menu/package.json
+++ b/packages/@navikt/process-menu/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.10",
+    "version": "1.0.11",
     "name": "@navikt/nap-process-menu",
     "author": "NAV",
     "license": "SEE LICENSE IN LICENSE",

--- a/packages/@navikt/process-menu/src/indexStyles.less
+++ b/packages/@navikt/process-menu/src/indexStyles.less
@@ -2,4 +2,15 @@
     display: flex;
     justify-content: space-between;
     padding: 0;
+    margin: 0;
+
+    .step {
+        &:first-child {
+            padding-left: 0;
+        }
+
+        &:last-child {
+            padding-right: 0;
+        }
+    }
 }


### PR DESCRIPTION
Fixes a couple of spacing issues in the usage of ProcessMenu:
- the first and last elements of the list no longer pads content to the left/right of the list
- margin and padding has been removed from the main list element entirely as the component has no border
or meaning outside of the component itself